### PR TITLE
Parse arguments using clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,11 +9,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -81,6 +98,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cloudabi"
@@ -330,9 +361,10 @@ dependencies = [
 
 [[package]]
 name = "kuppalista"
-version = "1.0.0-rc"
+version = "1.0.0"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -754,6 +786,11 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempfile"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +801,14 @@ dependencies = [
  "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1030,6 +1075,11 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1105,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vcpkg"
 version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1112,7 +1167,9 @@ dependencies = [
 
 [metadata]
 "checksum MacTypes-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7dbbe033994ae2198a18517c7132d952a29fb1db44249a1234779da7c50f4698"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
 "checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -1123,6 +1180,7 @@ dependencies = [
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
@@ -1200,7 +1258,9 @@ dependencies = [
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4790d0be6f4ba6ae4f48190efa2ed7780c9e3567796abdb285003cf39840d9c5"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
@@ -1223,10 +1283,12 @@ dependencies = [
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Real-time shopping list"
 
 [dependencies]
 bytes = "0.4"
+clap = "2.33.0"
 fs2 = "0.4"
 futures = "0.1"
 httparse = "1.3"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 Collaborative shopping list app using Rust, WebSockets and JavaScript.
 
-
 ## Usage
 
 Compile backend with `cargo build` to produce `./kuppalista` server executable.
 Start the server and access the application frontend with a web browser.
 
 ```
-usage: ./kuppalista [pkcs12] IP:PORT [password]
- e.g.: ./kuppalista tls.p12 127.0.0.1:8080 hunter2
+usage: ./kuppalista [-p password] [-b pkcs12] [--no-decrypt] IP:PORT
+ e.g.: ./kuppalista -p hunter2 -b tls.p12 127.0.0.1:8080
 ```
 
 PKCS#12 archive file and password are optional. If password is given, then
@@ -19,7 +18,6 @@ header to establish WebSocket connection to the server. The included frontend
 reads the password from `window.location.hash` so that a properly constructed
 link (e.g., [http://127.0.0.1:8080/#hunter2](http://127.0.0.1:8080/#hunter2))
 grants access to the password-protected shopping list.
-
 
 ## Security (or lack thereof)
 
@@ -31,7 +29,6 @@ broadcasted and shown to all clients. This has obvious security implications
 
 Thus, you probably do not want to make your shopping list public to all
 malicious people on the internet. Use TLS and password protection.
-
 
 ## Screenshot
 

--- a/src/rewind_stream.rs
+++ b/src/rewind_stream.rs
@@ -17,7 +17,7 @@ pub struct RewindStream<S> {
     buf_in: BytesMut,
     buf_out: BytesMut,
     last_req: BytesMut,
-    pass_through: bool
+    pass_through: bool,
 }
 
 impl<S> RewindStream<S> {
@@ -28,7 +28,7 @@ impl<S> RewindStream<S> {
             buf_in: BytesMut::new(),
             buf_out: BytesMut::new(),
             last_req: BytesMut::new(),
-            pass_through: false
+            pass_through: false,
         }
     }
 
@@ -40,7 +40,10 @@ impl<S> RewindStream<S> {
 
     /// Pass through data from now on (disables rewinding and HTTP parsing).
     pub fn pass_through(&mut self) {
-        assert!(!self.pass_through, "RewindStream::pass_through called twice");
+        assert!(
+            !self.pass_through,
+            "RewindStream::pass_through called twice"
+        );
         self.pass_through = true;
     }
 }
@@ -93,7 +96,7 @@ impl<S: Write> Write for RewindStream<S> {
     }
 }
 
-impl<S: AsyncRead> AsyncRead for RewindStream<S> { }
+impl<S: AsyncRead> AsyncRead for RewindStream<S> {}
 
 impl<S: AsyncWrite> AsyncWrite for RewindStream<S> {
     fn shutdown(&mut self) -> Result<Async<()>, std::io::Error> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,14 +5,14 @@ use tungstenite::protocol::Message;
 
 use std;
 use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
 use std::fs;
+use std::fs::{File, OpenOptions};
 use std::net::SocketAddr;
 use std::path::Path;
 
 fn align_len(len: usize) -> usize {
     let n = 4096;
-    n * (1 + (std::cmp::max(len, 1)-1) / n)
+    n * (1 + (std::cmp::max(len, 1) - 1) / n)
 }
 
 fn map(file: &File, len: usize) -> std::io::Result<MmapMut> {
@@ -26,7 +26,7 @@ pub struct State {
     file: File,
     mmap: Option<MmapMut>,
     len: usize,
-    size: usize // len padded to page boundary
+    size: usize, // len padded to page boundary
 }
 
 /// Initial state items.
@@ -38,13 +38,19 @@ impl State {
     pub fn new(json_path: &str, password: Option<String>) -> std::io::Result<State> {
         let exists = Path::new(json_path).exists();
 
-        let file = OpenOptions::new().read(true).write(true).create(true).open(json_path)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(json_path)?;
         file.try_lock_exclusive()?;
 
         let (mmap, len, size) = if exists {
             let file_len = fs::metadata(json_path)?.len() as usize;
             let size = align_len(file_len);
-            if file_len != size { file.set_len(size as u64)?; }
+            if file_len != size {
+                file.set_len(size as u64)?;
+            }
             let mmap = map(&file, size)?;
             let len = mmap.iter().position(|&x| x == 0).unwrap_or(size);
             (mmap, len, size)
@@ -63,7 +69,7 @@ impl State {
             file: file,
             mmap: Some(mmap),
             len: len,
-            size: size
+            size: size,
         })
     }
 
@@ -82,7 +88,9 @@ impl State {
 
         let buf = self.mmap.as_mut().unwrap();
         buf[..len].copy_from_slice(json.as_ref());
-        if len < size { buf[len] = 0; }
+        if len < size {
+            buf[len] = 0;
+        }
         self.len = len;
 
         buf.flush()


### PR DESCRIPTION
- Adds clap dependency
- Code formatted using `cargo fmt`
- Allows disabling PKCS #12 file decryption by passing `--no-decrypt` (in which case an empty string will be passed to `Identity::from_pkcs12`)
- Adds `AppError` enum, renames `ParseError` to `ArgsError` and makes its variants more specific
- Only handles errors in `fn main`, everything else is done in `fn my_main`